### PR TITLE
Feature/supported python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.1 (2024-08-08)
+ * Correcting Supported Python version constraint in pyproject.toml
+
 ## 4.0.0 (2024-07-08)
  * Moving from setup.py to pyproject.toml and poetry for installation
  * Introducing tox for platform independent testing of pep8 compliance.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1315,5 +1315,5 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "327bb1f967c37221f4326095ee6323715036ecda14e68d3cccb39833f1eee81c"
+python-versions = ">=3.8,<3.13"
+content-hash = "0f5ed68d8e3e78cd5f8001a4ae1648a908c21d2b23cb56681484d1f08cb86086"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipelinewise-singer-python"
-version = "4.0.0"
+version = "4.0.1"
 description = "Singer.io utility library - PipelineWise compatible"
 authors = []
 license = "Apache 2.0"
@@ -27,7 +27,7 @@ include = [
 
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = ">=3.8,<3.13"
 pytz = "^2018.4"
 jsonschema = "^4.19.2"
 msgspec = "^0.18.0"


### PR DESCRIPTION
# Description of change
Updating the supported python range from 3.8 - 3.12

# Manual QA steps
 - Ran tox and pip install
 
# Risks
 - Very little. Will create a new 4.0.1 release
 
# Rollback steps
 - revert this branch
